### PR TITLE
Chore/Update init files

### DIFF
--- a/rigsys/api/api_rig.py
+++ b/rigsys/api/api_rig.py
@@ -6,9 +6,7 @@ import os
 
 import maya.cmds as cmds
 
-import rigsys.modules.motion as motion
-import rigsys.modules.utility as utility
-import rigsys.modules.deformer as deformer
+from ..modules import motion, utility
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +82,7 @@ class Rig:
 
         # Sort by build order
         allModules.sort(key=lambda x: x.buildOrder)
-        
+
         return allModules
 
     def build(self, buildLevel: int = -1, buildProxiesOnly: bool = False, usedSavedProxyData: bool = False,
@@ -131,7 +129,7 @@ class Rig:
 
             if module.isMuted:
                 continue
-            
+
             if buildProxiesOnly:
                 if not module.bypassProxiesOnly and not isinstance(module, motion.MotionModuleBase):
                     logger.info(f"Skipping module {module.getFullName()} for buildProxiesOnly flag...")

--- a/rigsys/modules/__init__.py
+++ b/rigsys/modules/__init__.py
@@ -6,8 +6,4 @@ import rigsys.modules.utility as utility
 import rigsys.modules.export as export
 
 
-allModuleTypes = {}
-allModuleTypes.update(motion.moduleTypes)
-allModuleTypes.update(deformer.moduleTypes)
-allModuleTypes.update(utility.moduleTypes)
-allModuleTypes.update(export.moduleTypes)
+__all__ = ["motion", "deformer", "utility", "export"]

--- a/rigsys/modules/deformer/__init__.py
+++ b/rigsys/modules/deformer/__init__.py
@@ -1,36 +1,9 @@
-"""Deformer modules.
+"""Deformer modules."""
 
-The following code dynamically imports all subclasses of DeformerModuleBase present in this directory. That way, you can
-import any module in this directory and it will automatically be available in the rigging system.
-"""
+from .deformerBase import DeformerModuleBase
+from .skinClusterImportExport import skinClusterImportExport
 
-from os.path import dirname, basename, isfile, join
-import glob
-import importlib
-import inspect
-
-# This is the only line that needs to be changed per __init__.py file. Make sure to keep "as baseModule" at the end
-from .deformerBase import DeformerModuleBase as baseModule
-
-# Import all modules in the current directory
-modules = glob.glob(join(dirname(__file__), "*.py"))
-__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
-for module in __all__:
-    importlib.import_module('.' + module, package=str(__name__))
-
-# Get all the classes that inherit from baseModule
-classes = {str(baseModule.__name__): baseModule}
-for cls in baseModule.__subclasses__():
-    classes[cls.__name__] = cls
-    for subClass in cls.__subclasses__():
-        classes[subClass.__name__] = subClass
-
-# Import all the classes that inherit from baseModule
-for cls in classes.values():
-    classFilePath = inspect.getfile(cls)
-    importStatement = f"from .{basename(classFilePath)[:-3]} import {cls.__name__}"
-    exec(importStatement)
-
-__all__ = list(classes.keys())
-
-moduleTypes = classes.copy()
+__all__ = [
+    "DeformerModuleBase",
+    "skinClusterImportExport",
+]

--- a/rigsys/modules/export/__init__.py
+++ b/rigsys/modules/export/__init__.py
@@ -1,36 +1,11 @@
-"""Export modules.
+"""Export modules."""
 
-The following code dynamically imports all subclasses of ExportModuleBase present in this directory. That way, you can
-import any module in this directory and it will automatically be available in the rigging system.
-"""
+from .exportBase import ExportModuleBase
+from .fbxExport import FBXExport
+from .mbExport import MBExport
 
-from os.path import dirname, basename, isfile, join
-import glob
-import importlib
-import inspect
-
-# This is the only line that needs to be changed per __init__.py file. Make sure to keep "as baseModule" at the end
-from .exportBase import ExportModuleBase as baseModule
-
-# Import all modules in the current directory
-modules = glob.glob(join(dirname(__file__), "*.py"))
-__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
-for module in __all__:
-    importlib.import_module('.' + module, package=str(__name__))
-
-# Get all the classes that inherit from baseModule
-classes = {str(baseModule.__name__): baseModule}
-for cls in baseModule.__subclasses__():
-    classes[cls.__name__] = cls
-    for subClass in cls.__subclasses__():
-        classes[subClass.__name__] = subClass
-
-# Import all the classes that inherit from baseModule
-for cls in classes.values():
-    classFilePath = inspect.getfile(cls)
-    importStatement = f"from .{basename(classFilePath)[:-3]} import {cls.__name__}"
-    exec(importStatement)
-
-__all__ = list(classes.keys())
-
-moduleTypes = classes.copy()
+__all__ = [
+    "ExportModuleBase",
+    "FBXExport",
+    "MBExport",
+]

--- a/rigsys/modules/motion/__init__.py
+++ b/rigsys/modules/motion/__init__.py
@@ -1,36 +1,27 @@
-"""Motion modules.
+"""Motion modules."""
 
-The following code dynamically imports all subclasses of MotionModuleBase present in this directory. That way, you can
-import any module in this directory and it will automatically be available in the rigging system.
-"""
+from .motionBase import MotionModuleBase
+from .FK import FK
+from .FKRail import FKSegment
+from .IK import IK
+from .Root import Root
+from .floating import Floating
+from .hand import Hand
+from .limb import Limb
+from .quadLimb import QuadLimb
+from .ribbonBindIK import RibbonBindIK
+from .testMotionModule import TestMotionModule
 
-from os.path import dirname, basename, isfile, join
-import glob
-import importlib
-import inspect
-
-# This is the only line that needs to be changed per __init__.py file. Make sure to keep "as baseModule" at the end
-from .motionBase import MotionModuleBase as baseModule
-
-# Import all modules in the current directory
-modules = glob.glob(join(dirname(__file__), "*.py"))
-__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
-for module in __all__:
-    importlib.import_module('.' + module, package=str(__name__))
-
-# Get all the classes that inherit from baseModule
-classes = {str(baseModule.__name__): baseModule}
-for cls in baseModule.__subclasses__():
-    classes[cls.__name__] = cls
-    for subClass in cls.__subclasses__():
-        classes[subClass.__name__] = subClass
-
-# Import all the classes that inherit from baseModule
-for cls in classes.values():
-    classFilePath = inspect.getfile(cls)
-    importStatement = f"from .{basename(classFilePath)[:-3]} import {cls.__name__}"
-    exec(importStatement)
-
-__all__ = list(classes.keys())
-
-moduleTypes = classes.copy()
+__all__ = [
+    "MotionModuleBase",
+    "FK",
+    "FKSegment",
+    "IK",
+    "Root",
+    "Floating",
+    "Hand",
+    "Limb",
+    "QuadLimb",
+    "RibbonBindIK",
+    "TestMotionModule",
+]

--- a/rigsys/modules/utility/__init__.py
+++ b/rigsys/modules/utility/__init__.py
@@ -1,36 +1,15 @@
-"""Utility modules.
+"""Utility modules."""
 
-The following code dynamically imports all subclasses of UtilityModuleBase present in this directory. That way, you can
-import any module in this directory and it will automatically be available in the rigging system.
-"""
+from .utilityBase import UtilityModuleBase
+from .bindJoints import BindJoints
+from .importModel import ImportModel
+from .motionModuleParenting import MotionModuleParenting
+from .runPythonCode import PythonCode
 
-from os.path import dirname, basename, isfile, join
-import glob
-import importlib
-import inspect
-
-# This is the only line that needs to be changed per __init__.py file. Make sure to keep "as baseModule" at the end
-from .utilityBase import UtilityModuleBase as baseModule
-
-# Import all modules in the current directory
-modules = glob.glob(join(dirname(__file__), "*.py"))
-__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
-for module in __all__:
-    importlib.import_module('.' + module, package=str(__name__))
-
-# Get all the classes that inherit from baseModule
-classes = {str(baseModule.__name__): baseModule}
-for cls in baseModule.__subclasses__():
-    classes[cls.__name__] = cls
-    for subClass in cls.__subclasses__():
-        classes[subClass.__name__] = subClass
-
-# Import all the classes that inherit from baseModule
-for cls in classes.values():
-    classFilePath = inspect.getfile(cls)
-    importStatement = f"from .{basename(classFilePath)[:-3]} import {cls.__name__}"
-    exec(importStatement)
-
-__all__ = list(classes.keys())
-
-moduleTypes = classes.copy()
+__all__ = [
+    "UtilityModuleBase",
+    "BindJoints",
+    "ImportModel",
+    "MotionModuleParenting",
+    "PythonCode",
+]

--- a/rigsys/test/testRunner.py
+++ b/rigsys/test/testRunner.py
@@ -1,11 +1,12 @@
 """Run all tests in the test folder."""
 
 import logging
-import os
 import pytest
 import sys
 
 import maya.cmds as cmds
+
+from pathlib import Path
 
 from rigsys.utils.unload import unloadPackages, nukePycFiles
 
@@ -43,13 +44,10 @@ def runTests(pattern="test_"):
     unloadPackages(silent=False, packages=["rigsys"])
     nukePycFiles()
 
-    testPath = os.path.dirname(__file__)
+    test_path = Path(__file__).parent
+    fix_stdout()
 
-    try:
-        pytest.main([testPath, "-k", pattern])
-    except Exception:
-        logger.warning("Error running tests. Trying again with fixed stdout.")
-        fix_stdout()
+    pytest.main([test_path, "-k", pattern])
 
     cmds.file(new=True, force=True)
 


### PR DESCRIPTION
The `__init__.py` files for rig modules was overly complex. While it was nice that it made it so that you never have to update when you create new modules, it's needlessly complicated and it's preferred to just manually declare them. 

This could also give us the benefit of having an easy way to have "unpublished" modules, if they're just not included in their respective `__init__.py` file.

I also updated the test runner to always do the stdout fix, since I was still getting an error.

(Overall, this is mostly just fixing old, bad code that I wrote a while back)